### PR TITLE
Add two-factor authentication

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -38,8 +38,16 @@ export function LoginForm({
         password,
       });
       if (error) throw error;
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push("/protected");
+
+      const assuranceLevel = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (
+        assuranceLevel.data?.nextLevel === "aal2" &&
+        assuranceLevel.data?.nextLevel !== assuranceLevel.data?.currentLevel
+      ) {
+        router.push("/verify-mfa");
+      } else {
+        router.push("/protected");
+      }
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : "An error occurred");
     } finally {

--- a/lib/actions/mfa/checkAssuranceLevel.ts
+++ b/lib/actions/mfa/checkAssuranceLevel.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export const checkAssurance = async () => {
+  const supabase = await createClient()
+  await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+}

--- a/lib/actions/mfa/enrollMfa.ts
+++ b/lib/actions/mfa/enrollMfa.ts
@@ -1,0 +1,22 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export const enrollMFA = async () => {
+  const supabase = await createClient()
+
+  // Check current assurance level before enrolling
+  await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+
+  const { data, error } = await supabase.auth.mfa.enroll({
+    factorType: 'totp',
+  })
+  if (error) {
+    throw error
+  }
+
+  // Optionally check assurance level after enrolling
+  await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+
+  return data
+}

--- a/lib/actions/mfa/unEnrollMfa.ts
+++ b/lib/actions/mfa/unEnrollMfa.ts
@@ -1,0 +1,22 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export const unEnrollMFA = async () => {
+  const supabase = await createClient()
+
+  const factors = await supabase.auth.mfa.listFactors()
+  if (factors.error) {
+    throw factors.error
+  }
+
+  const factorId = factors.data.all[0]?.id
+  if (!factorId) {
+    return
+  }
+
+  const { error } = await supabase.auth.mfa.unenroll({ factorId })
+  if (error) {
+    throw error
+  }
+}

--- a/lib/actions/mfa/verifyMfa.ts
+++ b/lib/actions/mfa/verifyMfa.ts
@@ -1,0 +1,46 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export const verifyMFA = async (formData: FormData) => {
+  const supabase = await createClient()
+
+  const verificationCode = formData.get('verifyCode') as string
+
+  const factors = await supabase.auth.mfa.listFactors()
+  if (factors.error) {
+    throw factors.error
+  }
+
+  const factorId = factors.data.all[0]?.id
+  if (!factorId) {
+    throw new Error('No TOTP factors found!')
+  }
+
+  const challenge = await supabase.auth.mfa.challenge({ factorId })
+  if (challenge.error) {
+    throw challenge.error
+  }
+
+  const challengeId = challenge.data.id
+
+  const verify = await supabase.auth.mfa.verify({
+    factorId,
+    challengeId,
+    code: verificationCode,
+  })
+  if (verify.error) {
+    throw verify.error
+  }
+
+  const { error } = await supabase.auth.setSession({
+    access_token: verify.data?.access_token || '',
+    refresh_token: verify.data?.refresh_token || '',
+  })
+  if (error) {
+    throw error
+  }
+
+  redirect('/protected?mfaSuccess=true')
+}


### PR DESCRIPTION
## Summary
- add MFA enrollment and verification server actions
- update login form to check MFA assurance level

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adc493bc0832fb60144d594723ff9