### PR TITLE
Fix MFA session retrieval in settings

### DIFF
--- a/app/mfa/page.tsx
+++ b/app/mfa/page.tsx
@@ -11,13 +11,11 @@ export default function MFA({
 }) {
   const params = use(searchParams);
   const [qrCode, setQrCode] = useState<string | null>(null);
-  const [enrollmentData, setEnrollmentData] = useState<any>(null);
 
   const handleEnrollMFA = async () => {
     const mfa = await enrollMFA();
     console.log("MFA-->", mfa);
 
-    setEnrollmentData(mfa);
     setQrCode(mfa.totp.qr_code);
   };
 
@@ -80,14 +78,6 @@ export default function MFA({
               </p>
             )}
 
-            {/* {enrollmentData && (
-              <div className="mt-4 p-4 bg-gray-700 text-white rounded-lg">
-                <h3 className="font-semibold mb-2">Enrollment Data:</h3>
-                <pre className="text-xs overflow-x-auto">
-                  {JSON.stringify(enrollmentData, null, 2)}
-                </pre>
-              </div>
-            )} */}
           </div>
         </div>
       </div>

--- a/app/protected/settings/page.tsx
+++ b/app/protected/settings/page.tsx
@@ -2,8 +2,7 @@
 
 import React, { useEffect, useState, FormEvent } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
-import { Database } from '@/lib/database.types' // your Supabase typings
+import { createClient } from '@/lib/supabase/client'
 
 // ——— Typed ShadCN‐style UI components (same as before) ———
 type DivProps = React.HTMLAttributes<HTMLDivElement>
@@ -89,7 +88,7 @@ const Badge: React.FC<BadgeProps> = ({ className = '', children, ...props }) => 
 
 // ——— Main Settings component ———
 export default function Settings() {
-  const supabase = createClientComponentClient<Database>()
+  const supabase = createClient()
   const searchParams = useSearchParams()
   const message = searchParams.get('message')
 
@@ -102,6 +101,7 @@ export default function Settings() {
   useEffect(() => {
     ;(async () => {
       setLoading(true)
+      await supabase.auth.getSession()
       const { data, error } = await supabase.auth.mfa.listFactors()
       if (!error) {
         setHasMfa(data.factors.length > 0)


### PR DESCRIPTION
## Summary
- use `createClient` in Settings page instead of deprecated helper
- load session before listing MFA factors
- clean unused state in MFA page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686aec98ba38832f998d8d123d998284